### PR TITLE
Support for FabricSeasons' seasons tied to local time

### DIFF
--- a/common/src/main/java/club/iananderson/seasonhud/config/Config.java
+++ b/common/src/main/java/club/iananderson/seasonhud/config/Config.java
@@ -77,7 +77,7 @@ public class Config {
                 showDay = BUILDER
                         .comment("""
                                 Show the current day of the season/sub-season?
-                                NONE, SHOW_DAY, SHOW_WITH_TOTAL_DAYS
+                                NONE, SHOW_DAY, SHOW_WITH_TOTAL_DAYS, SHOW_WITH_MONTH
                                 Default is SHOW_DAY.""")
                         .defineEnum("enable_show_day",ShowDay.SHOW_DAY);
             BUILDER.pop();

--- a/common/src/main/java/club/iananderson/seasonhud/config/ShowDay.java
+++ b/common/src/main/java/club/iananderson/seasonhud/config/ShowDay.java
@@ -5,7 +5,8 @@ import net.minecraft.network.chat.Component;
 public enum ShowDay {
     NONE(0, "none"),
     SHOW_DAY(1, "showDay"),
-    SHOW_WITH_TOTAL_DAYS(2, "totalDays");
+    SHOW_WITH_TOTAL_DAYS(2, "totalDays"),
+    SHOW_WITH_MONTH(3, "showMonth");
 
     private final int idNum;
     private final String currentDayDisplay;

--- a/common/src/main/java/club/iananderson/seasonhud/event/SeasonHUDScreen.java
+++ b/common/src/main/java/club/iananderson/seasonhud/event/SeasonHUDScreen.java
@@ -86,12 +86,16 @@ public class SeasonHUDScreen extends Screen{
                         (b, Off) -> Config.setShowSubSeason(Off));
 
         row = 2;
+        ShowDay[] showDayValuesForge = { ShowDay.NONE,ShowDay.SHOW_DAY,ShowDay.SHOW_WITH_TOTAL_DAYS };
+        ShowDay[] showDayValuesFabric = { ShowDay.NONE,ShowDay.SHOW_DAY,ShowDay.SHOW_WITH_TOTAL_DAYS,ShowDay.SHOW_WITH_MONTH };
+        boolean isForge = Services.PLATFORM.getPlatformName() == "Forge";
         CycleButton<ShowDay> showDayButton = CycleButton.builder(ShowDay::getDayDisplayName)
-                .withValues(ShowDay.NONE,ShowDay.SHOW_DAY,ShowDay.SHOW_WITH_TOTAL_DAYS,ShowDay.SHOW_WITH_MONTH)
+                .withValues(isForge ? showDayValuesForge : showDayValuesFabric)
                 .withInitialValue(showDay.get())
                 .create(BUTTON_START_X_LEFT, (BUTTON_START_Y + (row * y_OFFSET)), BUTTON_WIDTH_HALF, BUTTON_HEIGHT,
                         Component.translatable("menu.seasonhud.button.showDay"),
                         (b, showDay) -> Config.setShowDay(showDay));
+
 
         CycleButton<Boolean> needCalendarButton = CycleButton.onOffBuilder(needCalendar.get())
                 .create(BUTTON_START_X_RIGHT, (BUTTON_START_Y + (row * y_OFFSET)), BUTTON_WIDTH_HALF, BUTTON_HEIGHT,

--- a/common/src/main/java/club/iananderson/seasonhud/event/SeasonHUDScreen.java
+++ b/common/src/main/java/club/iananderson/seasonhud/event/SeasonHUDScreen.java
@@ -87,7 +87,7 @@ public class SeasonHUDScreen extends Screen{
 
         row = 2;
         CycleButton<ShowDay> showDayButton = CycleButton.builder(ShowDay::getDayDisplayName)
-                .withValues(ShowDay.NONE,ShowDay.SHOW_DAY,ShowDay.SHOW_WITH_TOTAL_DAYS)
+                .withValues(ShowDay.NONE,ShowDay.SHOW_DAY,ShowDay.SHOW_WITH_TOTAL_DAYS,ShowDay.SHOW_WITH_MONTH)
                 .withInitialValue(showDay.get())
                 .create(BUTTON_START_X_LEFT, (BUTTON_START_Y + (row * y_OFFSET)), BUTTON_WIDTH_HALF, BUTTON_HEIGHT,
                         Component.translatable("menu.seasonhud.button.showDay"),

--- a/common/src/main/resources/assets/seasonhud/lang/en_us.json
+++ b/common/src/main/resources/assets/seasonhud/lang/en_us.json
@@ -21,6 +21,7 @@
 
   "menu.seasonhud.button.desc.showDay": "Show the day of of the current Season/Sub-Season on the HUD",
   "menu.seasonhud.button.desc.showSubSeason": "Replace the Season with the current Sub-Season",
+  "menu.seasonhud.button.desc.showMonth": "Show the current month, requires enabling isSeasonTiedWithSystemTime in the FabricSeasons config",
 
   "location.seasonhud.topLeft": "Top Left",
   "location.seasonhud.topCenter": "Top Center",
@@ -31,6 +32,7 @@
   "showday.seasonhud.none": "OFF",
   "showday.seasonhud.showDay": "Day #",
   "showday.seasonhud.totalDays": "Day #/#",
+  "showday.seasonhud.showMonth": "(Month), #",
 
   "desc.seasonhud.spring": "Spring",
   "desc.seasonhud.early_spring": "Early Spring",
@@ -69,6 +71,20 @@
   "desc.seasonhud.detailed": "%s, Day %s",
   "desc.seasonhud.detailed.total": "%s, Day %s/%s",
   "desc.seasonhud.combined": "%s%s",
+  "desc.seasonhud.month": "%s, %s %s",
+
+  "desc.seasonhud.january": "January",
+  "desc.seasonhud.february": "February",
+  "desc.seasonhud.march": "March",
+  "desc.seasonhud.april": "April",
+  "desc.seasonhud.may": "May",
+  "desc.seasonhud.june": "June",
+  "desc.seasonhud.july": "July",
+  "desc.seasonhud.august": "August",
+  "desc.seasonhud.september": "September",
+  "desc.seasonhud.october": "October",
+  "desc.seasonhud.november": "November",
+  "desc.seasonhud.december": "December",
 
   "item.calendar.tooltip": "Slot: Charm"
 }

--- a/fabric/src/main/java/club/iananderson/seasonhud/impl/seasons/CurrentSeason.java
+++ b/fabric/src/main/java/club/iananderson/seasonhud/impl/seasons/CurrentSeason.java
@@ -95,21 +95,13 @@ public class CurrentSeason {
         return null;
     }
 
-    public static int getSeasonLength() {
-        if(FabricSeasons.CONFIG.isSeasonTiedWithSystemTime()) {
-            LocalDateTime now = LocalDateTime.now();
-            return now.plusDays(/*FabricSeasons.getTimeToNextSystemSeason()*/0).getDayOfMonth();
-        }
-        return CONFIG.getSeasonLength() / 24000;
-    }
-
    //Localized name for the hud
     public static ArrayList<Component> getSeasonName() {
         ArrayList<Component> text = new ArrayList<>();
         ShowDay showDay = Config.showDay.get();
+        boolean isSeasonTiedWithSystemTime = FabricSeasons.CONFIG.isSeasonTiedWithSystemTime();
 
-        int seasonDuration = getSeasonLength();
-        LocalDateTime now = LocalDateTime.now();
+        int seasonDuration = CONFIG.getSeasonLength() / 24000;
 
         switch(showDay){
             case NONE ->{
@@ -129,8 +121,8 @@ public class CurrentSeason {
 
             case SHOW_WITH_MONTH -> {
                 text.add(Component.translatable("desc.seasonhud.icon", getSeasonIcon(getSeasonFileName())).withStyle(SEASON_STYLE));
-                if(FabricSeasons.CONFIG.isSeasonTiedWithSystemTime()) {
-                    text.add(Component.translatable("desc.seasonhud.month", Component.translatable("desc.seasonhud." + getSeasonStateLower()), Component.translatable("desc.seasonhud." + now.getMonth().name().toLowerCase()), getDate()));
+                if(isSeasonTiedWithSystemTime) {
+                    text.add(Component.translatable("desc.seasonhud.month", Component.translatable("desc.seasonhud." + getSeasonStateLower()), Component.translatable("desc.seasonhud." + getCurrentMonth().name().toLowerCase()), getDate()));
                 } else {
                     text.add(Component.translatable("desc.seasonhud.detailed", Component.translatable("desc.seasonhud." + getSeasonStateLower()), getDate()));
                 }

--- a/fabric/src/main/java/club/iananderson/seasonhud/impl/seasons/CurrentSeason.java
+++ b/fabric/src/main/java/club/iananderson/seasonhud/impl/seasons/CurrentSeason.java
@@ -6,6 +6,8 @@ import io.github.lucaargolo.seasons.FabricSeasons;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 
+import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.Objects;
 
@@ -59,11 +61,28 @@ public class CurrentSeason {
 
     //Get the current date of the season
     public static int getDate() {
+
+        if(FabricSeasons.CONFIG.isSeasonTiedWithSystemTime()) {
+            int dayOfMonth = getSystemDayOfMonth();
+            return dayOfMonth;
+        }
         Minecraft mc = Minecraft.getInstance();
         int worldTime = Math.toIntExact(Objects.requireNonNull(mc.level).getDayTime());
         int seasonDate = ((int)(worldTime - (worldTime / (long)CONFIG.getSeasonLength() * (long)CONFIG.getSeasonLength())) % CONFIG.getSeasonLength() / 24000)+1;
 
         return seasonDate;
+    }
+
+    // Get the current day of month from the system; used with fabric seasons' system time tied with season option
+    public static int getSystemDayOfMonth() {
+        LocalDateTime now = LocalDateTime.now();
+        int dayOfMonth = now.getDayOfMonth();
+        return dayOfMonth;
+    }
+
+    public static Month getCurrentMonth() {
+        LocalDateTime now = LocalDateTime.now();
+        return now.getMonth();
     }
 
     //Get the current season and match it to the icon for the font
@@ -76,12 +95,21 @@ public class CurrentSeason {
         return null;
     }
 
+    public static int getSeasonLength() {
+        if(FabricSeasons.CONFIG.isSeasonTiedWithSystemTime()) {
+            LocalDateTime now = LocalDateTime.now();
+            return now.plusDays(/*FabricSeasons.getTimeToNextSystemSeason()*/0).getDayOfMonth();
+        }
+        return CONFIG.getSeasonLength() / 24000;
+    }
+
    //Localized name for the hud
     public static ArrayList<Component> getSeasonName() {
         ArrayList<Component> text = new ArrayList<>();
         ShowDay showDay = Config.showDay.get();
 
-        int seasonDuration = CONFIG.getSeasonLength() / 24000;
+        int seasonDuration = getSeasonLength();
+        LocalDateTime now = LocalDateTime.now();
 
         switch(showDay){
             case NONE ->{
@@ -97,6 +125,15 @@ public class CurrentSeason {
             case SHOW_WITH_TOTAL_DAYS ->{
                 text.add(Component.translatable("desc.seasonhud.icon",getSeasonIcon(getSeasonFileName())).withStyle(SEASON_STYLE));
                 text.add(Component.translatable("desc.seasonhud.detailed.total",Component.translatable("desc.seasonhud." + getSeasonStateLower()), getDate(), seasonDuration));
+            }
+
+            case SHOW_WITH_MONTH -> {
+                text.add(Component.translatable("desc.seasonhud.icon", getSeasonIcon(getSeasonFileName())).withStyle(SEASON_STYLE));
+                if(FabricSeasons.CONFIG.isSeasonTiedWithSystemTime()) {
+                    text.add(Component.translatable("desc.seasonhud.month", Component.translatable("desc.seasonhud." + getSeasonStateLower()), Component.translatable("desc.seasonhud." + now.getMonth().name().toLowerCase()), getDate()));
+                } else {
+                    text.add(Component.translatable("desc.seasonhud.detailed", Component.translatable("desc.seasonhud." + getSeasonStateLower()), getDate()));
+                }
             }
         }
 


### PR DESCRIPTION
I've added support for FabricSeasons' seasons tied to local time feature. This feature probably doesn't exist in SereneSeasons, so I've only touched the Fabric side of things. The feature has been disabled on Forge.
## What needs to be done:
* Localization to other languages