### PR TITLE
## [1.10.7] - 2024-09-21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+## [1.10.7] - 2024-09-18
+
+### Fixed
+
+- Fixed the "Calendar Detail Mode" option showing the wrong total days
+
+### Changed
+
+- Changed to allow "Calendar Detail Mode" season/day display mode to be customized like normal.
+    - Now, if the option is enabled, it should force just the season name to be displayed when there
+      is not a calendar in the player's inventory.
+    - If a calendar is found, it will display using the season/day settings set in the
+      config/options screen.
+
 ## [1.10.6] - 2024-09-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
-## [1.10.7] - 2024-09-18
+## [1.10.7] - 2024-09-21
 
 ### Fixed
 

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ subprojects {
                 "minecraft_version_range"   : minecraft_version_range,
                 "fabric_api_version"        : fabric_api_version,
                 "fabric_loader_version"     : fabric_loader_version,
-                "fabric_version_range": fabric_version_range,
+                "fabric_version_range"      : fabric_version_range,
                 "mod_name"                  : mod_name,
                 "mod_author"                : mod_author,
                 "mod_id"                    : mod_id,

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.fabric_loader_version}"
 
     api "fuzs.forgeconfigapiport:forgeconfigapiport-common:${project.forge_config_api_port_version}"
-    modImplementation("io.wispforest:accessories-common:${project.accessories_version}")
+    modCompileOnly("io.wispforest:accessories-common:${project.accessories_version}-mojmap")
 
     // Minimap Mods
     // Not used in common unless they are actually  loaded.

--- a/common/src/main/java/club/iananderson/seasonhud/client/gui/components/buttons/CheckButton.java
+++ b/common/src/main/java/club/iananderson/seasonhud/client/gui/components/buttons/CheckButton.java
@@ -1,0 +1,76 @@
+package club.iananderson.seasonhud.client.gui.components.buttons;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractButton;
+import net.minecraft.client.gui.narration.NarratedElementType;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+
+public class CheckButton extends AbstractButton {
+  private static final ResourceLocation TEXTURE = new ResourceLocation("textures/gui/checkbox.png");
+  private static final int TEXT_COLOR = 14737632;
+  private final float scale;
+  private final OnPress onPress;
+  private boolean selected;
+
+  public CheckButton(int x, int y, int width, int height, Component text, float scale, OnPress onPress,
+      boolean selected) {
+    super(x, y, width, height, text);
+    this.scale = scale;
+    this.onPress = onPress;
+    this.selected = selected;
+  }
+
+  public CheckButton(int x, int y, Component component, float scale, OnPress onPress, boolean selected) {
+    this(x, y, (int) (20 * scale), (int) (20 * scale), component, scale, onPress, selected);
+  }
+
+  public void onPress() {
+    this.selected = !this.selected;
+    this.onPress.onPress(this);
+  }
+
+  public boolean selected() {
+    return this.selected;
+  }
+
+  public void updateWidgetNarration(NarrationElementOutput narrationElementOutput) {
+    narrationElementOutput.add(NarratedElementType.TITLE, this.createNarrationMessage());
+    if (this.active) {
+      if (this.isFocused()) {
+        narrationElementOutput.add(NarratedElementType.USAGE,
+                                   Component.translatable("narration.checkbox.usage.focused"));
+      } else {
+        narrationElementOutput.add(NarratedElementType.USAGE,
+                                   Component.translatable("narration.checkbox.usage.hovered"));
+      }
+    }
+  }
+
+  public void renderWidget(GuiGraphics graphics, int i, int j, float f) {
+    Minecraft mc = Minecraft.getInstance();
+    Font font = mc.font;
+    RenderSystem.enableDepthTest();
+    graphics.setColor(1.0F, 1.0F, 1.0F, this.alpha);
+    RenderSystem.enableBlend();
+    graphics.pose().pushPose();
+    graphics.pose().scale(scale, scale, 1);
+    graphics.blit(TEXTURE, (int) (this.getX() / scale), (int) (this.getY() / scale), this.isFocused() ? 20.0F : 0.0F,
+                  this.selected ? 20.0F : 0.0F, (int) (this.width / scale), (int) (this.height / scale), 64, 64);
+    graphics.setColor(1.0F, 1.0F, 1.0F, 1.0F);
+
+    graphics.pose().translate((this.width / scale) + 4, ((this.height / scale) - 8) / 2, 0);
+    graphics.drawString(font, this.getMessage(), (int) (this.getX() / scale), (int) (this.getY() / scale),
+                        14737632 | Mth.ceil(this.alpha * 255.0F) << 24);
+    graphics.pose().popPose();
+  }
+
+  public interface OnPress {
+    void onPress(CheckButton button);
+  }
+}

--- a/common/src/main/java/club/iananderson/seasonhud/client/gui/screens/SeasonOptionsScreen.java
+++ b/common/src/main/java/club/iananderson/seasonhud/client/gui/screens/SeasonOptionsScreen.java
@@ -3,6 +3,7 @@ package club.iananderson.seasonhud.client.gui.screens;
 import club.iananderson.seasonhud.Common;
 import club.iananderson.seasonhud.client.gui.Location;
 import club.iananderson.seasonhud.client.gui.ShowDay;
+import club.iananderson.seasonhud.client.gui.components.buttons.CheckButton;
 import club.iananderson.seasonhud.client.gui.components.sliders.BasicSlider;
 import club.iananderson.seasonhud.client.gui.components.sliders.HudOffsetSlider;
 import club.iananderson.seasonhud.config.Config;
@@ -84,16 +85,6 @@ public class SeasonOptionsScreen extends SeasonHudScreen {
   public void render(@NotNull GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
     xSlider.active = hudLocationButton.getValue() == Location.TOP_LEFT;
     ySlider.active = hudLocationButton.getValue() == Location.TOP_LEFT;
-
-    if (Common.extrasLoaded() && Config.getCalanderDetailMode()) {
-      Config.setShowDay(ShowDay.NONE);
-      showDayButton.active = false;
-
-      if (Common.platformName().equals("Forge")) {
-        Config.setShowSubSeason(false);
-        showSubSeasonButton.active = false;
-      }
-    }
 
     MutableComponent seasonCombined = CurrentSeason.getInstance(this.minecraft).getSeasonHudText();
 
@@ -221,6 +212,24 @@ public class SeasonOptionsScreen extends SeasonHudScreen {
                 Config.setCalanderDetailMode(val);
                 rebuildWidgets();
               });
+
+      float scale = 0.45F;
+
+      CheckButton showTotal = new CheckButton((rightButtonX + BUTTON_WIDTH + BUTTON_PADDING),
+                                              (buttonStartY + (row * yOffset)), Component.literal("Show Total Days"),
+                                              scale, (b) -> {
+        if (b.selected()) {
+          Config.setShowDay(ShowDay.SHOW_WITH_TOTAL_DAYS);
+        } else {
+          Config.setShowDay((ShowDay.SHOW_DAY));
+        }
+      }, Config.getShowDay() == ShowDay.SHOW_WITH_TOTAL_DAYS);
+
+      CheckButton showSubSeason = new CheckButton((rightButtonX + BUTTON_WIDTH + BUTTON_PADDING),
+                                                  (int) (buttonStartY + (row * yOffset) + BUTTON_HEIGHT - (20 * scale)),
+                                                  Component.literal(String.valueOf(showTotal.selected())), scale,
+                                                  (b) -> Config.setShowSubSeason(b.selected()),
+                                                  Config.getShowSubSeason());
       widgets.addAll(Arrays.asList(needCalendarButton, calanderDetailModeButton));
     }
 

--- a/common/src/main/java/club/iananderson/seasonhud/client/overlays/SeasonHUDOverlayCommon.java
+++ b/common/src/main/java/club/iananderson/seasonhud/client/overlays/SeasonHUDOverlayCommon.java
@@ -26,7 +26,7 @@ public class SeasonHUDOverlayCommon {
     int stringWidth = mc.font.width(seasonCombined);
     int stringHeight = mc.font.lineHeight;
 
-    if (Common.drawDefaultHud() && Common.vanillaShouldDrawHud() && Calendar.calendarFound()) {
+    if (Common.drawDefaultHud() && Common.vanillaShouldDrawHud() && Calendar.validNeedCalendar()) {
       switch (Config.getHudLocation()) {
         case TOP_LEFT:
           x = xOffset;

--- a/common/src/main/java/club/iananderson/seasonhud/impl/minimaps/CurrentMinimap.java
+++ b/common/src/main/java/club/iananderson/seasonhud/impl/minimaps/CurrentMinimap.java
@@ -122,7 +122,7 @@ public class CurrentMinimap {
     boolean enabled = Config.getEnableMod() && Config.getEnableMinimapIntegration();
     boolean hiddenMinimap = Services.MINIMAP.hideHudInCurrentDimension() || hiddenMinimap(minimap);
 
-    return enabled && Calendar.calendarFound() && !mc.options.hideGui && !hiddenMinimap;
+    return enabled && Calendar.validNeedCalendar() && !mc.options.hideGui && !hiddenMinimap;
   }
 
   public enum Minimap {

--- a/common/src/main/java/club/iananderson/seasonhud/impl/seasons/Calendar.java
+++ b/common/src/main/java/club/iananderson/seasonhud/impl/seasons/Calendar.java
@@ -16,7 +16,7 @@ public class Calendar {
                                                                                                            item);
   }
 
-  public static boolean calendarFound() {
+  private static boolean calendarFound() {
     Minecraft mc = Minecraft.getInstance();
     Item calendar = Services.SEASON.calendar();
 
@@ -28,22 +28,14 @@ public class Calendar {
       return false;
     }
 
-    return findCalendar(mc.player, calendar) || !Config.getNeedCalendar();
+    return findCalendar(mc.player, calendar);
   }
 
-  public static boolean calendarFoundDetailed() {
-    Minecraft mc = Minecraft.getInstance();
-    Item calendar = Services.SEASON.calendar();
-
-    if (Common.platformName().equals("Fabric") && !Common.extrasLoaded()) {
-      return false;
-    }
-
-    if (mc.level == null || mc.player == null || calendar == null) {
-      return false;
-    }
-
-    return findCalendar(mc.player, calendar) && Config.getCalanderDetailMode();
+  public static boolean validNeedCalendar() {
+    return (Config.getNeedCalendar() && Calendar.calendarFound()) || !Config.getNeedCalendar();
   }
 
+  public static boolean validDetailedMode() {
+    return (Config.getCalanderDetailMode() && Calendar.calendarFound()) || !Config.getCalanderDetailMode();
+  }
 }

--- a/common/src/main/java/club/iananderson/seasonhud/impl/seasons/CurrentSeason.java
+++ b/common/src/main/java/club/iananderson/seasonhud/impl/seasons/CurrentSeason.java
@@ -33,14 +33,22 @@ public class CurrentSeason {
     return new CurrentSeason(mc);
   }
 
-  //Convert Season to lower case (for localized names)
-  public String getSeasonStateLower() {
-    if ((Config.getShowSubSeason() || Calendar.calendarFoundDetailed()) && currentSubSeason.contains("_")) {
-      String lowerSubSeason = currentSubSeason.toLowerCase();
-      return currentSeason.toLowerCase() + "." + lowerSubSeason.substring(0, lowerSubSeason.indexOf("_"));
-    } else {
-      return currentSeason.toLowerCase();
+  public String getSubSeasonLowerCase() {
+    String lowerSubSeason = currentSubSeason.toLowerCase();
+    return currentSeason.toLowerCase() + "." + lowerSubSeason.substring(0, lowerSubSeason.indexOf("_"));
+  }
+
+  public String getSeasonLowerCase() {
+    return currentSeason.toLowerCase();
+  }
+
+  public Component getSeasonKey() {
+    String season = Config.getShowSubSeason() ? getSubSeasonLowerCase() : getSeasonLowerCase();
+    if (!Calendar.validDetailedMode()) {
+      season = getSeasonLowerCase();
     }
+
+    return Component.translatable("desc.seasonhud.season." + season);
   }
 
   //Get the current season and match it to the icon for the font
@@ -55,24 +63,28 @@ public class CurrentSeason {
 
   //Localized name for the hud with icon
   public Component getText() {
-    Component season = Component.translatable("desc.seasonhud.season." + getSeasonStateLower());
     Component text = Component.literal("");
 
     switch (Config.getShowDay()) {
       case NONE:
-        text = Component.translatable(ShowDay.NONE.getKey(), season);
-
-        if (Calendar.calendarFoundDetailed()) {
-          text = Component.translatable(ShowDay.SHOW_WITH_TOTAL_DAYS.getKey(), season, seasonDate, seasonDuration);
-        }
+        text = Component.translatable(ShowDay.NONE.getKey(), getSeasonKey());
         break;
 
       case SHOW_DAY:
-        text = Component.translatable(ShowDay.SHOW_DAY.getKey(), season, seasonDate);
+        text = Component.translatable(ShowDay.SHOW_DAY.getKey(), getSeasonKey(), seasonDate);
+
+        if (!Calendar.validDetailedMode()) {
+          text = Component.translatable(ShowDay.NONE.getKey(), getSeasonKey());
+        }
         break;
 
       case SHOW_WITH_TOTAL_DAYS:
-        text = Component.translatable(ShowDay.SHOW_WITH_TOTAL_DAYS.getKey(), season, seasonDate, seasonDuration);
+        text = Component.translatable(ShowDay.SHOW_WITH_TOTAL_DAYS.getKey(), getSeasonKey(), seasonDate,
+                                      seasonDuration);
+
+        if (!Calendar.validDetailedMode()) {
+          text = Component.translatable(ShowDay.NONE.getKey(), getSeasonKey());
+        }
         break;
 
       case SHOW_WITH_MONTH:
@@ -86,9 +98,13 @@ public class CurrentSeason {
 
           Component currentMonth = Component.translatable("desc.seasonhud.month." + systemMonthString);
 
-          text = Component.translatable(ShowDay.SHOW_WITH_MONTH.getKey(), season, currentMonth, seasonDate);
+          text = Component.translatable(ShowDay.SHOW_WITH_MONTH.getKey(), getSeasonKey(), currentMonth, seasonDate);
+
+          if (!Calendar.validDetailedMode()) {
+            text = Component.translatable(ShowDay.NONE.getKey(), getSeasonKey());
+          }
         } else {
-          text = Component.translatable(ShowDay.SHOW_DAY.getKey(), season, seasonDate);
+          text = Component.translatable(ShowDay.SHOW_DAY.getKey(), getSeasonKey(), seasonDate);
         }
         break;
     }

--- a/common/src/main/java/club/iananderson/seasonhud/impl/seasons/CurrentSeason.java
+++ b/common/src/main/java/club/iananderson/seasonhud/impl/seasons/CurrentSeason.java
@@ -43,10 +43,13 @@ public class CurrentSeason {
   }
 
   public Component getSeasonKey() {
-    String season = Config.getShowSubSeason() ? getSubSeasonLowerCase() : getSeasonLowerCase();
-    if (!Calendar.validDetailedMode()) {
+    String season;
+
+    if (!Calendar.validDetailedMode() || Common.platformName().equals("Fabric")) {
       season = getSeasonLowerCase();
     }
+
+    else season = Config.getShowSubSeason() ? getSubSeasonLowerCase() : getSeasonLowerCase();
 
     return Component.translatable("desc.seasonhud.season." + season);
   }

--- a/forge/src/main/java/club/iananderson/seasonhud/forge/platform/ForgeSeasonHelper.java
+++ b/forge/src/main/java/club/iananderson/seasonhud/forge/platform/ForgeSeasonHelper.java
@@ -63,7 +63,7 @@ public class ForgeSeasonHelper implements ISeasonHelper {
     int subSeasonDate = (seasonDay % subSeasonDuration) + 1; //Default 8 days in each sub-season (1 week)
     int seasonDate = (seasonDay % (subSeasonDuration * 3)) + 1; //Default 24 days in a season (8 days * 3)
 
-    if (Config.getShowSubSeason() || Calendar.calendarFoundDetailed()) {
+    if (Config.getShowSubSeason()) {
       if (isTropicalSeason(player)) {
         // Default 16 days in each tropical "sub-season".
         // Starts are "Early Dry" (Summer 1), so need to offset Spring 1 -> Summer 1 (subSeasonDuration * 3)
@@ -88,7 +88,7 @@ public class ForgeSeasonHelper implements ISeasonHelper {
       seasonDuration *= 2; //Tropical seasons are twice as long (Default 48 days)
     }
 
-    if (Config.getShowSubSeason()) {
+    if (Config.getShowSubSeason() && Calendar.validDetailedMode()) {
       seasonDuration /= 3; //3 sub-seasons per season
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx4G
 org.gradle.parallel=true
 # Project
-mod_version=1.10.6
+mod_version=1.10.7
 mod_group=club.iananderson
 java_version=17
 credits=IanAnderson
@@ -78,8 +78,8 @@ ftb_teams_forge_version=5267190
 # https://modrinth.com/mod/architectury-api/versions?g=1.20.1&l=forge
 # https://modrinth.com/mod/moonlight/versions?g=1.20.1&l=forge
 # https://modrinth.com/mod/immediatelyfast/versions?g=1.20.1&l=forge
-xaeros_minimap_version=24.3.0
-journeymap_version=5.10.1
+xaeros_minimap_version=24.4.0
+journeymap_version=5.10.2
 journeymap_api_version_fabric=1.20-1.9-fabric-SNAPSHOT
 architectury_version=9.2.14
 moonlight_version=2.12.11
@@ -90,7 +90,7 @@ immediatelyfast_version=1.2.20
 # https://modrinth.com/mod/accessories/versions?g=1.20.1&l=fabric
 curios_version=5.9.1+1.20.1
 trinkets_version=3.7.2
-accessories_version=1.0.0-beta.30+1.20.1
+accessories_version=1.0.0-beta.35+1.20.1
 # Development QOL
 # Create Fabric supports all 3 recipe viewers: JEI, REI, and EMI. This decides which is enabled at runtime.
 # set to disabled to have none of them.


### PR DESCRIPTION
## [1.10.7] - 2024-09-21

### Fixed

- Fixed the "Calendar Detail Mode" option showing the wrong total days

### Changed

- Changed to allow "Calendar Detail Mode" season/day display mode to be customized like normal.
    - Now, if the option is enabled, it should force just the season name to be displayed when there
      is not a calendar in the player's inventory.
    - If a calendar is found, it will display using the season/day settings set in the
      config/options screen.