### PR TITLE
Update dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,12 +33,12 @@ curseforge_fabric_id=848022
 curseforge_gameVersions=1.20,1.20.1
 # Forge properties
 # https://files.minecraftforge.net/net/minecraftforge/forge/index_1.20.1.html
-forge_version=1.20.1-47.3.5
+forge_version=1.20.1-47.4.13
 forge_version_range=[46,)
 forge_loader_version_range=[46,)
 # Fabric properties
 # https://fabricmc.net/develop/
-fabric_loader_version=0.17.2
+fabric_loader_version=0.18.2
 fabric_api_version=0.92.6+1.20.1
 fabric_version_range=>=1.20 <=1.20.1
 # Neoforge properties
@@ -48,7 +48,7 @@ neoforge_version_range=
 neoforge_loader_version_range=
 # ForgeConfigApiPort properties
 # https://modrinth.com/mod/forge-config-api-port/versions?g=1.20.1&l=fabric
-forge_config_api_port_version=8.0.2
+forge_config_api_port_version=8.0.3
 #Season Mods
 # https://modrinth.com/mod/serene-seasons/versions?g=1.20.1&l=forge
 # https://modrinth.com/mod/glitchcore/versions?g=1.20.1&l=forge
@@ -62,7 +62,7 @@ serene_seasons_version=1.20.1-9.1.0.2
 glitchcore_version=1.20.1-0.0.1.1
 fabric_seasons_version=2.4.2-BETA+1.20
 fabric_seasons_extras_version=1.3.2-BETA+1.20
-terrafirmacraft_version=3.2.16
+terrafirmacraft_version=3.2.19
 patchouli_version=1.20.1-84.1-forge
 barrels_version=2.1
 ecliptic_seasons_version=7014423
@@ -90,10 +90,10 @@ journeymap_version_forge=1.20.1-5.10.3-forge
 journeymap_api_version_fabric=1.20-1.9-fabric-SNAPSHOT
 architectury_version=9.2.14
 map_atlases_version=1.20-6.0.17
-moonlight_version_forge=1.20-2.14.13-forge
-moonlight_version_fabric=1.20-2.14.13-fabric
-immediatelyfast_version=1.5.1
-ftb_library_version=2001.2.10
+moonlight_version_forge=1.20-2.16.16-forge
+moonlight_version_fabric=1.20-2.16.16-fabric
+immediatelyfast_version=1.5.3
+ftb_library_version=2001.2.12
 ftb_teams_version=2001.3.1
 ftb_chunks_version=2001.3.6
 #Curios/Trinkets/Accessories


### PR DESCRIPTION
fabric_loader_version: 0.17.2 => 0.18.2
fabric_api_version: 0.92.6+1.20.1 => 0.92.6+1.20.1 (no change)
forge_version: 1.20.1-47.3.5 => 1.20.1-47.4.13
devauth_version: 1.2.1 => 1.2.1 (no change)
forge_config_api_port_version: 8.0.2 => 8.0.3
modmenu_version: 7.2.2 => 7.2.2 (no change)
serene_seasons_version: 1.20.1-9.1.0.2 => 1.20.1-9.1.0.2 (no change)
glitchcore_version: 1.20.1-0.0.1.1 => 1.20.1-0.0.1.1 (no change)
terrafirmacraft_version: 3.2.16 => 3.2.19
patchouli_version: 1.20.1-84.1-forge => 1.20.1-84.1-forge (no change)
xaeros_minimap_version: 25.2.10 => 25.2.10 (no change)
journeymap_version_forge: 1.20.1-5.10.3-forge => 1.20.1-5.10.3-forge (no change)
journeymap_version_fabric: 1.20.1-5.10.3-fabric => 1.20.1-5.10.3-fabric (no change)
ftb_chunks_version: 2001.3.6 => 2001.3.6 (no change)
ftb_teams_version: 2001.3.1 => 2001.3.1 (no change)
ftb_library_version: 2001.2.10 => 2001.2.12
architectury_version: 9.2.14 => 9.2.14 (no change)
map_atlases_version: 1.20-6.0.17 => 1.20-6.0.17 (no change)
moonlight_version_forge: 1.20-2.14.13-forge => 1.20-2.16.16-forge
moonlight_version_fabric: 1.20-2.14.13-fabric => 1.20-2.16.16-fabric
immediatelyfast_version: 1.5.1 => 1.5.3